### PR TITLE
Use general v1 as the default pretrained model

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ uvx --from "hoct[bioio]" hoct track \
 [ctc]: https://celltrackingchallenge.net/datasets/
 
 No model is specified above, so HOCT downloads the default pre-trained model
-(`general_v0`) and caches it; later runs reuse the cache. To use your own
+(`general_v1`) and caches it; later runs reuse the cache. To use the model
+trained for Cell Tracking Challenge data, pass `-m ctc_v0`; to use your own
 checkpoint, pass `-m /path/to/model.pt`. Set `HOCT_CACHE_DIR` to change where
 downloads are cached.
 
@@ -91,7 +92,7 @@ This produces the standard CTC layout (`maskNNN.tif` per timepoint plus
 | Flag | Default | What it does |
 |---|---|---|
 | `-o, --output` | *required* | Output GEFF directory |
-| `-m, --model` | `general_v0` | Checkpoint path or registered model name; the default is downloaded on first use |
+| `-m, --model` | `general_v1` | Checkpoint path or registered model name (for example, `ctc_v0`); the default is downloaded on first use |
 | `-f, --format` | `geff` | `geff` or `ctc` (Cell Tracking Challenge folder) |
 | `-d, --device` | `cuda` | `cuda`, `mps`, or `cpu` (auto-falls back to CPU if needed) |
 | `--tile` | `auto` | `auto`/`on`/`off`. Tiled inference for large data; auto-enables when the candidate graph has more than 2500 edges per timepoint. Tile shape `(t, z, y, x) = (1, 64, 256, 256)`, overlap `(2, 24, 64, 64)`. |
@@ -186,15 +187,22 @@ tiled inference, test-time augmentation, etc.).
 `load_model()` (and the CLI without `-m`) fetch a JIT-compiled checkpoint from
 the project's GitHub releases, verify its SHA256, and cache it under the OS
 cache directory (override with `HOCT_CACHE_DIR`). List the available names with
-`hoct.available_models()`. The registry lives in `src/hoct/_models.py`.
+`hoct.available_models()`. The registered models are:
+
+- `general_v1` — the default model for general datasets;
+- `ctc_v0` — the model trained for Cell Tracking Challenge datasets;
+- `general_v0` — the previous general model, retained for reproducibility.
+
+Select one by passing its name to `load_model()` or to the CLI's `--model` /
+`-m` option. The registry lives in `src/hoct/_models.py`.
 
 ### Publishing new weights (maintainers)
 
-1. Create a GitHub release whose tag matches `_RELEASE_BASE` in
-   `src/hoct/_models.py` (e.g. `weights-v0`) and upload the `.pt` asset.
+1. Create a GitHub release with a new weights tag (e.g. `weights-v2`) and
+   upload the `.pt` asset.
 2. Compute its hash: `shasum -a 256 model.pt`.
-3. Add an entry to `MODELS` in `src/hoct/_models.py` with the asset URL and
-   hash, and bump `DEFAULT_MODEL` if it should become the default.
+3. Add an entry to `MODELS` in `src/hoct/_models.py` with the tagged release
+   asset URL and hash, and bump `DEFAULT_MODEL` if it should become the default.
 
 ## Development
 

--- a/src/hoct/_models.py
+++ b/src/hoct/_models.py
@@ -15,19 +15,27 @@ from pathlib import Path
 import pooch
 import torch
 
-# Base URL for release assets. Bump the tag when publishing new weights.
-_RELEASE_BASE = "https://github.com/royerlab/hoct/releases/download/weights-v0"
+# Base URL for release assets. Each model URL includes its weights release tag.
+_RELEASES_BASE = "https://github.com/royerlab/hoct/releases/download"
 
 # Registry of distributed models: name -> {url, sha256}.
 MODELS: dict[str, dict[str, str]] = {
+    "general_v1": {
+        "url": f"{_RELEASES_BASE}/weights-v1/general_v1.pt",
+        "sha256": "5bd836dfcb15ad796ea79a9595841a3e73b650a71c4acba3fc66aac65d745b33",
+    },
+    "ctc_v0": {
+        "url": f"{_RELEASES_BASE}/weights-v0/ctc_v0.pt",
+        "sha256": "b9be3d976e2d51ae946128ded99142a81b5ba99fb87a0da67c38de2934944000",
+    },
     "general_v0": {
-        "url": f"{_RELEASE_BASE}/general_v0.pt",
+        "url": f"{_RELEASES_BASE}/weights-v0/general_v0.pt",
         "sha256": "024c2e4606275c96667907abfc9e0c27487b543480caf99d9ebd1d267cef8e4a",
     },
 }
 
 #: Model used when none is specified.
-DEFAULT_MODEL = "general_v0"
+DEFAULT_MODEL = "general_v1"
 
 
 def available_models() -> list[str]:

--- a/src/hoct/_tests/conftest.py
+++ b/src/hoct/_tests/conftest.py
@@ -20,15 +20,15 @@ requires_geff_data = pytest.mark.skipif(
 )
 
 # Pre-trained checkpoint used by the inference tests. Defaults to the weights
-# kept under `weights/general_v0.pt`; override with HOCT_TEST_MODEL.
+# kept under `weights/general_v1.pt`; override with HOCT_TEST_MODEL.
 MODEL_PATH = Path(
     os.environ.get(
         "HOCT_TEST_MODEL",
-        str(Path(__file__).resolve().parents[3] / "weights" / "general_v0.pt"),
+        str(Path(__file__).resolve().parents[3] / "weights" / "general_v1.pt"),
     )
 )
 
 requires_model = pytest.mark.skipif(
     not MODEL_PATH.exists(),
-    reason="pre-trained model not available (set HOCT_TEST_MODEL or place weights/general_v0.pt)",
+    reason="pre-trained model not available (set HOCT_TEST_MODEL or place weights/general_v1.pt)",
 )

--- a/src/hoct/_tests/test_models.py
+++ b/src/hoct/_tests/test_models.py
@@ -59,8 +59,30 @@ class TestResolveModel:
         with pytest.raises(FileNotFoundError):
             _models.resolve_model(tmp_path / "missing.pt")
 
-    def test_available_models_includes_default(self):
+    def test_general_v1_is_default(self):
+        assert _models.DEFAULT_MODEL == "general_v1"
         assert _models.DEFAULT_MODEL in _models.available_models()
+
+    @pytest.mark.parametrize(
+        ("name", "release", "sha256"),
+        [
+            (
+                "general_v1",
+                "weights-v1",
+                "5bd836dfcb15ad796ea79a9595841a3e73b650a71c4acba3fc66aac65d745b33",
+            ),
+            (
+                "ctc_v0",
+                "weights-v0",
+                "b9be3d976e2d51ae946128ded99142a81b5ba99fb87a0da67c38de2934944000",
+            ),
+        ],
+    )
+    def test_published_model_is_registered(self, name: str, release: str, sha256: str):
+        assert _models.MODELS[name] == {
+            "url": f"https://github.com/royerlab/hoct/releases/download/{release}/{name}.pt",
+            "sha256": sha256,
+        }
 
 
 class TestModelDownload:


### PR DESCRIPTION
Publishes and registers `general_v1` from the new [`weights-v1`](https://github.com/royerlab/hoct/releases/tag/weights-v1) release, makes it the default, and registers the existing `ctc_v0` checkpoint so users can select it with `--model ctc_v0`. The previous `general_v0` remains available for reproducibility, and the docs and test fixture default are updated.

Tests: `uvx ruff@0.11.12 check .`, `uvx ruff@0.11.12 format --check .`, and `uv run --no-sync pytest -q` (78 passed, 49 skipped). Both remote assets were also downloaded, checksum-verified, and loaded as TorchScript models.