### PR TITLE
Pass Scale to RegionPropsNodes

### DIFF
--- a/src/hoct/features/graph.py
+++ b/src/hoct/features/graph.py
@@ -174,6 +174,7 @@ def create_graph(
 
     td.nodes.RegionPropsNodes(
         extra_properties=extra_properties,
+        spacing=scale[1:],
     ).add_nodes(graph, labels=labels, intensity_image=images)
 
     # Add scaled position attributes


### PR DESCRIPTION
Hi Jordao,
as Max mentioned in the email, we had an issue with hoct handling the scale parameter of our anisotropic data correctly. This change seems to fix the issue for us.
Best,
Leon & Max